### PR TITLE
feat: Add tfstate to Azure Blob Storage (and minor changes)

### DIFF
--- a/bicep/infra.bicep
+++ b/bicep/infra.bicep
@@ -28,9 +28,6 @@ param vmName string = 'simple-vm'
 @description('VM Size, can be Standard_B8ms or Standard_B20ms')
 param vmSize string = 'Standard_B8ms'
 
-// TODO: Handle multiple vm size
-// Standard_B8ms & Standard_B20ms
-
 var defaultTags = {
   vmName: vmName
   fromTemplate: 'true'

--- a/terraform/guacamole.tf
+++ b/terraform/guacamole.tf
@@ -110,7 +110,7 @@ resource "azurerm_service_plan" "guac-service-plan" {
   resource_group_name = azurerm_resource_group.rg.name
   location            = var.location
   os_type             = "Linux"
-  sku_name            = "P1v2"
+  sku_name            = "B2"
 }
 
 resource "azurerm_linux_web_app" "guacamole-web-app" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -35,7 +35,7 @@ resource "azurerm_key_vault" "key-vault" {
 
   access_policy {
     tenant_id = data.azurerm_client_config.current.tenant_id
-    object_id = data.azurerm_client_config.current.object_id
+    object_id = var.az_account_object_id
 
     key_permissions = [
       "Get"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -7,6 +7,13 @@ terraform {
     random = {}
   }
 
+  backend "azurerm" {
+    resource_group_name  = "euphrosyne-01-tfstate"
+    storage_account_name = "euphrosyne01tfstatestg"
+    container_name       = "euphrosyne-01-tfstate-stg-tfstate"
+    key                  = "terraform.tfstate"
+  }
+
   required_version = ">= 1.1.0"
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -29,3 +29,8 @@ variable "bastion_password" {
   type      = string
   sensitive = true
 }
+
+variable "az_account_object_id" {
+  type      = string
+  sensitive = true
+}


### PR DESCRIPTION
Add a `backend` config to save the tfstate on Azure Blob Storage to save & share it more easily.